### PR TITLE
feat: add generic heap

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,7 @@ AtomicValue is a wrapper around sync/atomic.Value.
 ## SyncPool
 
 SyncPool is a wrapper for sync.Pool
+
+## Heap
+
+Heap is a heap-like wrapper for container/heap

--- a/heap.go
+++ b/heap.go
@@ -1,0 +1,59 @@
+package gwrap
+
+import (
+	"container/heap"
+)
+
+type innerHeap[T any] struct {
+	slice []T
+	less  func(T, T) bool
+}
+
+// Heap is implemented with container/heap and is not thread-safe
+type Heap[T any] struct {
+	i innerHeap[T]
+}
+
+// NewHeap creates a Heap from a comparison function.
+func NewHeap[T any](less func(a T, b T) bool) *Heap[T] {
+	i := innerHeap[T]{
+		slice: make([]T, 0, 100),
+		less:  less,
+	}
+	heap.Init(&i)
+	return &Heap[T]{
+		i: i,
+	}
+}
+
+// Code below originated with the container/heap documentation
+
+func (h *innerHeap[T]) Len() int           { return len(h.slice) }
+func (h *innerHeap[T]) Less(i, j int) bool { return h.less(h.slice[i], h.slice[j]) }
+func (h *innerHeap[T]) Swap(i, j int)      { h.slice[i], h.slice[j] = h.slice[j], h.slice[i] }
+
+// Push is O(log n)
+func (h *Heap[T]) Push(x T) {
+	heap.Push(&h.i, x)
+}
+
+func (h *innerHeap[T]) Push(x any) {
+	h.slice = append(h.slice, x.(T))
+}
+
+// Pop is O(log n)
+func (h *Heap[T]) Pop() T {
+	return heap.Pop(&h.i).(T)
+}
+
+func (h *innerHeap[T]) Pop() any {
+	old := h.slice
+	n := len(old)
+	x := old[n-1]
+	h.slice = old[0 : n-1]
+	return x
+}
+
+func (h Heap[T]) Len() int {
+	return len(h.i.slice)
+}

--- a/heap_test.go
+++ b/heap_test.go
@@ -1,0 +1,29 @@
+package gwrap_test
+
+import (
+	"testing"
+
+	"github.com/muir/gwrap"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHeap(t *testing.T) {
+	h := gwrap.NewHeap(func(a float64, b float64) bool {
+		return a < b
+	})
+	assert.Equal(t, 0, h.Len())
+	h.Push(1.7)
+	h.Push(5.9)
+	h.Push(3.4)
+	assert.Equal(t, 3, h.Len())
+	assert.Equal(t, 1.7, h.Pop())
+	assert.Equal(t, 2, h.Len())
+	h.Push(2.7)
+	h.Push(4.2)
+	assert.Equal(t, 2.7, h.Pop())
+	assert.Equal(t, 3.4, h.Pop())
+	assert.Equal(t, 4.2, h.Pop())
+	assert.Equal(t, 5.9, h.Pop())
+	assert.Equal(t, 0, h.Len())
+}


### PR DESCRIPTION
Adds a simple generic heap that supports Push(), Pop(), and Len().
The comparison function must be provided.